### PR TITLE
refactor: optimite config for HtmlBundlerPlugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "cssnano-preset-advanced": "^6.0.1",
         "daisyui": "^3.9.4",
         "glob-all": "^3.3.1",
-        "html-bundler-webpack-plugin": "^2.15.2",
+        "html-bundler-webpack-plugin": "^3.5.2",
         "nodemon": "^3.0.1",
         "nunjucks": "^3.2.4",
         "postcss-loader": "^7.3.3",
@@ -311,6 +311,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/html-minifier-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-7.0.2.tgz",
+      "integrity": "sha512-mm2HqV22l8lFQh4r2oSsOEVea+m0qqxEmwpc9kC1p/XzmjLWrReR9D/GRs8Pex2NX/imyEH9c5IU/7tMBQCHOA==",
+      "dev": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.3",
@@ -769,9 +775,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-1.5.6.tgz",
-      "integrity": "sha512-vKn0k5V0oiaOClcUMNDFb7DvI3+asAozhg1wI8bLkYxV0lhfPtIuwjUa1wG9/YaUY/KwO9U2B7m0FMqzn/jXUQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-2.0.3.tgz",
+      "integrity": "sha512-tcSGX0mhuDFHsgRrT56xnZ9v2X+TOeKhJ75YopI5OBgyT7tGaG5m6BmeC+6KHjiucfBvUHehQMecHbULIAkFPA==",
       "dev": true,
       "engines": {
         "node": ">=12.13"
@@ -2528,12 +2534,13 @@
       }
     },
     "node_modules/html-bundler-webpack-plugin": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-2.15.2.tgz",
-      "integrity": "sha512-h5jlKCy1MK7h5C9lR3USvfJvoIFVxWQkFpAncraY+nWnIRfZtTw35la+1Aw9TLnX8Xl1CZeGegbOEZ/fL7Sk4g==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-3.5.3.tgz",
+      "integrity": "sha512-WR1lBLZ7k/5pYJRRoX3C1O/lJZuxA48UUqDh5NVznEvHBhY5XVkMEGYxRg3DQmqby3kxN3NWWaY/XGYrnop/1A==",
       "dev": true,
       "dependencies": {
-        "ansis": "1.5.6",
+        "@types/html-minifier-terser": "^7.0.2",
+        "ansis": "2.0.3",
         "enhanced-resolve": ">=5.7.0",
         "eta": "^3.1.1",
         "html-minifier-terser": "^7.2.0"
@@ -2547,14 +2554,23 @@
       },
       "peerDependencies": {
         "ejs": ">=3.1.9",
+        "favicons": ">=7.1.4",
         "handlebars": ">=4.7.7",
         "liquidjs": ">=10.7.0",
+        "markdown-it": ">=13.0.1",
         "mustache": ">=4.2.0",
         "nunjucks": ">=3.2.3",
+        "parse5": ">=7.1.2",
+        "prismjs": ">=1.29.0",
+        "pug": ">=3.0.2",
+        "twig": ">=1.17.1",
         "webpack": ">=5.32.0"
       },
       "peerDependenciesMeta": {
         "ejs": {
+          "optional": true
+        },
+        "favicons": {
           "optional": true
         },
         "handlebars": {
@@ -2563,10 +2579,25 @@
         "liquidjs": {
           "optional": true
         },
+        "markdown-it": {
+          "optional": true
+        },
         "mustache": {
           "optional": true
         },
         "nunjucks": {
+          "optional": true
+        },
+        "parse5": {
+          "optional": true
+        },
+        "prismjs": {
+          "optional": true
+        },
+        "pug": {
+          "optional": true
+        },
+        "twig": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cssnano-preset-advanced": "^6.0.1",
     "daisyui": "^3.9.4",
     "glob-all": "^3.3.1",
-    "html-bundler-webpack-plugin": "^2.15.2",
+    "html-bundler-webpack-plugin": "^3.5.2",
     "nodemon": "^3.0.1",
     "nunjucks": "^3.2.4",
     "postcss-loader": "^7.3.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require("path")
 const HtmlBundlerPlugin = require("html-bundler-webpack-plugin")
-const Nunjucks = require("nunjucks")
 const glob = require("glob-all")
 const dataGlobal = require("./src/data/_global.json")
 
@@ -66,12 +65,17 @@ module.exports = (env, argv) => {
             return `assets/css/${filename}`
           },
         },
-        loaderOptions: {
-          preprocessor: (template, { data }) => {
-            const njk = Nunjucks.configure(path.join(__dirname, "src/views/"))
-            njk.addGlobal("global", dataGlobal)
-            return njk.renderString(template, data)
-          },
+        // pass data into all pages with the object name `global`
+        data: {
+          global: dataGlobal,
+        },
+        // use the build-in nunjucks preprocessor
+        preprocessor: 'nunjucks',
+        preprocessorOptions: {
+          // define here the Nunjucks options
+          views: [
+            'src/views/',
+          ],
         },
         minify: {
           collapseWhitespace: false,


### PR DESCRIPTION
Hello @IndraSukma,

I'm the author of the [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) and want  help you configure the plugin.

The plugin already can compile many template engines, including the [Nunjucks](https://github.com/IndraSukma/tw-vetsasap/compare/master...webdiscus:tw-vetsasap:master#using-template-nunjucks), out of the box.

So you can specify the `preprocessor: 'nunjucks'` option for usage the nunjucks templates.
The nunjucks specifically options can be defined in the `preprocessorOptions`.

To pass the global data into all pages (independent of templating engine) use the `data` option.